### PR TITLE
Update reward symmetry on win/loss

### DIFF
--- a/src/gymnasium_backgammon/envs/backgammon_env.py
+++ b/src/gymnasium_backgammon/envs/backgammon_env.py
@@ -71,18 +71,16 @@ class BackgammonEnv(gym.Env):
             self.game.get_opponent(self.current_agent)
         ))
 
-        reward = 0
+        reward = 0.0
         terminated = False
         truncated = False
 
         winner = self.game.get_winner()
 
         if winner is not None:
-            # practical-issues-in-temporal-difference-learning, pag.3
-            # …leading to a final reward signal z. In the simplest case,
-            # z = 1 if White wins and z = 0 if Black wins
-            if winner == WHITE:
-                reward = 1
+            # Assign symmetrical rewards to both players at the end of the game
+            # so that a win always yields ``+1.0`` and a loss ``-1.0``.
+            reward = 1.0 if winner == self.current_agent else -1.0
             terminated = True
         elif self.counter > self.max_length_episode:
             truncated = True


### PR DESCRIPTION
## Summary
- modify reward logic in `BackgammonEnv.step()` so each player gets `+1.0` for a win and `-1.0` for a loss

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb24cd2b48331b8fc1000974e4f76