### PR TITLE
Add training script for PPO

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+
+import gymnasium as gym
+from gymnasium.envs.registration import register
+
+from gymnasium_backgammon.wrappers.action_wrapper import BackgammonActionWrapper
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timesteps", type=int, required=True)
+    parser.add_argument("--learning-rate", type=float, required=True)
+    args = parser.parse_args()
+
+    try:
+        register(
+            id="gymnasium_backgammon:backgammon-v0",
+            entry_point="gymnasium_backgammon.envs:BackgammonEnv",
+            disable_env_checker=True,
+        )
+    except Exception:
+        # Environment might already be registered
+        pass
+
+    env = gym.make("gymnasium_backgammon:backgammon-v0")
+    env = BackgammonActionWrapper(env)
+
+    from stable_baselines3 import PPO
+
+    model = PPO(
+        "MlpPolicy",
+        env,
+        learning_rate=args.learning_rate,
+        tensorboard_log="logs",
+        verbose=1,
+    )
+
+    model.learn(total_timesteps=args.timesteps)
+
+    os.makedirs("models", exist_ok=True)
+    model.save("models/ppo_backgammon")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a `train.py` script to train PPO on the Backgammon environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880854840d483318d8886897280de04