### PR TITLE
Add CI workflow and update gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run tests
+        run: pytest --maxfail=1 --disable-warnings -q

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ venv.bak/
 .DS_Store
 .AppleDouble
 .LSOverride
+# Project-specific
+models/


### PR DESCRIPTION
## Summary
- ignore models folder in git
- run tests on Python 3.10 using GitHub Actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*
- `pip install -e .[test]` *(fails to finish due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68809019e5b483319104fb1068f52e96